### PR TITLE
Update version retrieval for 3dcitydb version 4, add sql rollback on error

### DIFF
--- a/citydb_explorer_dockwidget.py
+++ b/citydb_explorer_dockwidget.py
@@ -141,7 +141,7 @@ class CityDbExplorerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
             else:
                 # It is not a 3DCity DB. Reset the db_interface to None
-                self.dbVersion.setText("Error. Current DB is not a 3DCity DB.")
+                self.dbVersion.setText("Error. Current DB is not a 3DCity DB or is an unsupported version.") 
                 self.db_interface = None
 
     def load_building(self):


### PR DESCRIPTION
Not sure if this repo is still active, but here goes:

It looks like between version 3 and 4, the version function was changed.

CityDB version 3
![image](https://github.com/3dcitydb/3dcitydb-qgis-explorer/assets/58328424/784d221b-6d42-4392-9211-994c3d4a9922)

CityDB version 4
![image](https://github.com/3dcitydb/3dcitydb-qgis-explorer/assets/58328424/e4a25ffa-dd31-4fc2-b880-cd0c5bcd32f9)

When a v4 db is loaded, a silent error occurs where the program just returns a -1 instead of stopping.
https://github.com/3dcitydb/3dcitydb-qgis-explorer/blob/6ed4bf022f7c4b883a7e35c73df9cca16c62d538/db/postgresql.py#L132-L141

However, due to the error, further SQL transactions are blocked until a rollback is executed, and so the next sql call to retrieve the citydb srs fails as described in #6. 

"current transaction is aborted, commands ignored until end of transaction block"

This PR adds code to handle version retrieval for v3 and v4, as well as connection rollbacks to the exception handling. However, there maybe be other api changes in v4 that have not been addressed.